### PR TITLE
Add share button to context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import {
   PencilIcon,
   Plus,
   SearchIcon,
+  Share,
   Star,
   TrashIcon,
 } from "lucide-react";
@@ -706,6 +707,43 @@ function App() {
                     >
                       <Check className="size-4" /> Mark as{" "}
                       {bookmark.title.endsWith(" [read]") ? "unread" : "read"}
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      onSelect={async () => {
+                        const shareData = {
+                          title: bookmark.title.endsWith(" [read]") 
+                            ? trimEnd(bookmark.title, " [read]")
+                            : bookmark.title,
+                          url: bookmark.url!,
+                        };
+
+                        // Try to use Web Share API if available
+                        if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
+                          try {
+                            await navigator.share(shareData);
+                            toast("Bookmark shared successfully");
+                          } catch (error) {
+                            if (error instanceof Error && error.name !== 'AbortError') {
+                              // Fallback to clipboard if share was not cancelled
+                              await navigator.clipboard.writeText(`${shareData.title} - ${shareData.url}`);
+                              toast("Bookmark copied to clipboard");
+                            }
+                          }
+                        } else {
+                          // Fallback to clipboard
+                          try {
+                            await navigator.clipboard.writeText(`${shareData.title} - ${shareData.url}`);
+                            toast("Bookmark copied to clipboard");
+                          } catch (error) {
+                            toast("Failed to copy bookmark", {
+                              description: "Unable to access clipboard",
+                            });
+                          }
+                        }
+                      }}
+                    >
+                      <Share className="size-4" />
+                      Share
                     </ContextMenuItem>
                     <ContextMenuItem
                       onSelect={() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -711,33 +711,43 @@ function App() {
                     <ContextMenuItem
                       onSelect={async () => {
                         const shareData = {
-                          title: bookmark.title.endsWith(" [read]") 
+                          title: bookmark.title.endsWith(" [read]")
                             ? trimEnd(bookmark.title, " [read]")
                             : bookmark.title,
                           url: bookmark.url!,
                         };
 
                         // Try to use Web Share API if available
-                        if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
+                        if (
+                          navigator.share &&
+                          navigator.canShare &&
+                          navigator.canShare(shareData)
+                        ) {
                           try {
                             await navigator.share(shareData);
                             toast("Bookmark shared successfully");
                           } catch (error) {
-                            if (error instanceof Error && error.name !== 'AbortError') {
-                              // Fallback to clipboard if share was not cancelled
-                              await navigator.clipboard.writeText(`${shareData.title} - ${shareData.url}`);
+                            if (
+                              error instanceof Error &&
+                              error.name !== "AbortError"
+                            ) {
+                              await navigator.clipboard.writeText(
+                                `${shareData.title} - ${shareData.url}`
+                              );
                               toast("Bookmark copied to clipboard");
                             }
                           }
                         } else {
-                          // Fallback to clipboard
                           try {
-                            await navigator.clipboard.writeText(`${shareData.title} - ${shareData.url}`);
+                            await navigator.clipboard.writeText(
+                              `${shareData.title} - ${shareData.url}`
+                            );
                             toast("Bookmark copied to clipboard");
                           } catch (error) {
                             toast("Failed to copy bookmark", {
                               description: "Unable to access clipboard",
                             });
+                            console.log(error);
                           }
                         }
                       }}


### PR DESCRIPTION
A share button was added to the context menu when right-clicking an item in Tabisphere.

Changes in `src/App.tsx`:
*   The `Share` icon was imported from `lucide-react`.
*   A new `ContextMenuItem` for "Share" was inserted between the "Mark as read/unread" and "Delete" options.
*   The `onSelect` handler for the "Share" item was implemented to:
    *   Attempt to use the Web Share API (`navigator.share`) if supported and `navigator.canShare` confirms the data can be shared.
    *   Fall back to copying the bookmark's title and URL to the clipboard if the Web Share API is unavailable or fails (excluding user-aborted actions).
    *   Clean the bookmark title by removing the " [read]" suffix before sharing or copying.
    *   Display toast notifications for user feedback on success or failure.

This provides a modern sharing experience with a robust fallback, ensuring the share functionality is available across different browser capabilities.